### PR TITLE
np.bool is deprecated

### DIFF
--- a/pyhdfe/algorithms.py
+++ b/pyhdfe/algorithms.py
@@ -381,7 +381,7 @@ class MAP(FixedPoint):
         u = residual.copy()
 
         # identify vectors that can be accelerated
-        last_apply = np.ones(ssr.size, np.bool)
+        last_apply = np.ones(ssr.size, bool)
         apply = ssr.flatten() >= self._acceleration_tol
 
         # iterate until termination
@@ -531,7 +531,7 @@ class LSMR(FixedPoint):
         # iterate until each vector converges
         iterations = 0
         matrix = matrix.copy()
-        converged = np.zeros(j, np.bool)
+        converged = np.zeros(j, bool)
         while True:
             last_matrix = None if self._converged is None else matrix.copy()
             for i, vector in enumerate(matrix_transpose):

--- a/pyhdfe/utilities.py
+++ b/pyhdfe/utilities.py
@@ -29,7 +29,7 @@ class Groups(object):
         sorted_ids = flat[self.sort_indices]
 
         # identify groups
-        changes = np.ones(sorted_ids.shape, np.bool)
+        changes = np.ones(sorted_ids.shape, bool)
         changes[1:] = sorted_ids[1:] != sorted_ids[:-1]
         self.reduce_indices = np.nonzero(changes)[0]
 


### PR DESCRIPTION
this PR replaces the use of np.bool with bool to fix AttributeError when using pyhdfe with the latest NumPy release. bool is identical to np.bool as described in (https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated)